### PR TITLE
[マージ不要] Upgrade v4.6.4 without android TASK-393

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,8 +48,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.brother.sdk:printer:4.6.1'
-    implementation 'com.brother.typeb:print:1.0.0'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/android/src/main/kotlin/com/rouninlabs/another_brother/method/PrintFileListMethodCall.kt
+++ b/android/src/main/kotlin/com/rouninlabs/another_brother/method/PrintFileListMethodCall.kt
@@ -59,7 +59,7 @@ class PrintFileListMethodCall(
                                     OpenChannelError.ErrorCode.NoError -> ErrorCode.NoError
                                     OpenChannelError.ErrorCode.OpenStreamFailure -> ErrorCode.ChannelErrorStreamStatusError
                                     OpenChannelError.ErrorCode.Timeout -> ErrorCode.ChannelTimeout
-                                    null -> ErrorCode.UnknownError
+                                    else -> ErrorCode.UnknownError
                                 },
                             ),
                         )

--- a/ios/Classes/Method/BrotherUtils.m
+++ b/ios/Classes/Method/BrotherUtils.m
@@ -256,6 +256,9 @@ static NSObject<FlutterPluginRegistrar>* _registrarFlutter;
     else if([@"PT_P910BT" isEqualToString:name]) {
         return BRLMPrinterModelPT_P910BT;
     }
+    else if([@"RJ_3230B" isEqualToString:name]) {
+        return BRLMPrinterModelRJ_3230B;
+    }
     else if([@"RJ_3250WB" isEqualToString:name]) {
         return BRLMPrinterModelRJ_3250WB;
     }


### PR DESCRIPTION
* Androidは 4.6.1以降のaarを使ったところ、releaseビルドのみ、openChannelで落ちてしまう問題があり、4.5.1のまま
https://uuuo.slack.com/archives/C05UU2J06MV/p1698908754586849

* iOSは4.6.4にupgrade